### PR TITLE
fix helpers.mkdirp on windows

### DIFF
--- a/compiler.co
+++ b/compiler.co
@@ -774,10 +774,7 @@ helpers.mkdirp = mkdirp = function mkdirp (p, mode=8r0755, cb)
     exists <- path.exists p
     return cb null if exists
     
-    ps = p.split('/')
-    _p = ps.slice(0, -1).join('/')
-    
-    err <- mkdirp _p, mode
+    err <- mkdirp (path.dirname p), mode
     return cb null if err?.code is 'EEXIST'
     return cb err  if err
     

--- a/compiler.js
+++ b/compiler.js
@@ -935,13 +935,10 @@ helpers.mkdirp = mkdirp = (function(){
     cb || (cb = function(){});
     p = expand(p);
     return path.exists(p, function(exists){
-      var ps, _p;
       if (exists) {
         return cb(null);
       }
-      ps = p.split('/');
-      _p = ps.slice(0, -1).join('/');
-      return mkdirp(_p, mode, function(err){
+      return mkdirp(path.dirname(p), mode, function(err){
         if ((err != null ? err.code : void 8) === 'EEXIST') {
           return cb(null);
         }


### PR DESCRIPTION
`path.dirname` do things better than split-slice-join the path assuming `/` is directory seperator, may also easier to read
