### PR TITLE
Change from path.exists to fs.exists because it's deprecated in Node >= 0.8

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -950,7 +950,7 @@ helpers.mkdirp = mkdirp = (function(){
     }
     cb || (cb = function(){});
     p = expand(p);
-    return path.exists(p, function(exists){
+    return fs.exists(p, function(exists){
       var ps, _p;
       if (exists) {
         return cb(null);


### PR DESCRIPTION
Yup, Node is giving me deprecation warnings, but no more with this simple fix. :)
